### PR TITLE
maint: be explicit about which env vars are injected into containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,9 +7,9 @@ services:
     pull_policy: never
     ports:
       - "127.0.0.1:10115:10115"
-    env_file:
-      - .env
     environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_HEADERS
       - OTEL_SERVICE_NAME=backend-for-frontend
     depends_on:
       image-picker:
@@ -27,9 +27,10 @@ services:
     pull_policy: never
     ports:
       - "127.0.0.1:10116:10116"
-    env_file:
-      - .env
     environment:
+      - BUCKET_NAME
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_HEADERS
       - OTEL_SERVICE_NAME=image-picker-ruby
 
   meminator:
@@ -40,9 +41,9 @@ services:
     pull_policy: never
     ports:
       - "127.0.0.1:10117:10117"
-    env_file:
-      - .env
     environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_HEADERS
       - OTEL_SERVICE_NAME=meminator-ruby
 
   phrase-picker:
@@ -53,9 +54,9 @@ services:
     pull_policy: never
     ports:
       - "127.0.0.1:10118:10118"
-    env_file:
-      - .env
     environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_HEADERS
       - OTEL_SERVICE_NAME=phrase-picker-ruby
 
   web:


### PR DESCRIPTION
## Which problem is this PR solving?

Feedback from @jessitron: "Let's be explicit so it is clear which vars are going into which containers. Less magic!"

## Short description of the changes

- Brings the explicit list of env vars to inject into containers back into docker-compose.yaml. (Which is how the other projects do things, too.)

